### PR TITLE
Add node links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hamedkarbasi93-nodegraphapi-datasource",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -75,11 +75,9 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
               url:  field['link__url'] || "",
               title: field['link__title'] || "Link",
               "internal": {
-                "query": {
-                  "expr": field['link__expr'],
-                },
-                "datasourceUid": field['link__uid'],
-                "datasourceName": field['link__name']
+              "query": {"expr": field['link__expr']},
+              "datasourceUid": field['link__uid'],
+              "datasourceName": field['link__name']
               }
             }];
           }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -10,9 +10,7 @@ import {
   FieldColorModeId,
 } from '@grafana/data';
 
-import { getBackendSrv } from '@grafana/runtime';
-
-import { getTemplateSrv } from '@grafana/runtime';
+import { getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 
 import { MyQuery, MyDataSourceOptions, defaultQuery } from './types';
 
@@ -66,7 +64,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
             outputField.config.links = [{
               url: field['link__url'],
               title: field['link__title'] || "Link",
-              targetBlank: true
+              targetBlank: true,
             }];
           }
           // add single internal link for items (link__expr, link__uid, link__name)
@@ -77,7 +75,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
               "internal": {
               "query": {"expr": field['link__expr']},
               "datasourceUid": field['link__uid'],
-              "datasourceName": field['link__name']
+              "datasourceName": field['link__name'],
               }
             }];
           }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -61,6 +61,28 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
           if ('displayName' in field) {
             outputField.config.displayName = field['displayName'];
           }
+          // add single external link for items (link__url, link__title)
+          if ('link__url' in field) {
+            outputField.config.links = [{
+              url: field['link__url'],
+              title: field['link__title'] || "Link",
+              targetBlank: true
+            }];
+          }
+          // add single internal link for items (link__expr, link__uid, link__name)
+          if (('link__expr' in field) && ('link__uid' in field)) {
+            outputField.config.links = [{
+              url:  field['link__url'] || "",
+              title: field['link__title'] || "Link",
+              "internal": {
+                "query": {
+                  "expr": field['link__expr'],
+                },
+                "datasourceUid": field['link__uid'],
+                "datasourceName": field['link__name']
+              }
+            }];
+          }
           outputFields.push(outputField);
         });
         return outputFields;

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -61,23 +61,27 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
           }
           // add single external link for items (link__url, link__title)
           if ('link__url' in field) {
-            outputField.config.links = [{
-              url: field['link__url'],
-              title: field['link__title'] || "Link",
-              targetBlank: true,
-            }];
+            outputField.config.links = [
+              {
+                url: field['link__url'],
+                title: field['link__title'] || 'Link',
+                targetBlank: true,
+              },
+            ];
           }
           // add single internal link for items (link__expr, link__uid, link__name)
-          if (('link__expr' in field) && ('link__uid' in field)) {
-            outputField.config.links = [{
-              url:  field['link__url'] || "",
-              title: field['link__title'] || "Link",
-              "internal": {
-              "query": {"expr": field['link__expr']},
-              "datasourceUid": field['link__uid'],
-              "datasourceName": field['link__name'],
-              }
-            }];
+          if ('link__expr' in field && 'link__uid' in field) {
+            outputField.config.links = [
+              {
+                url: field['link__url'] || '',
+                title: field['link__title'] || 'Link',
+                internal: {
+                  query: { expr: field['link__expr'] },
+                  datasourceUid: field['link__uid'],
+                  datasourceName: field['link__name'],
+                },
+              },
+            ];
           }
           outputFields.push(outputField);
         });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "baseUrl": "./src",
-    "typeRoots": ["./node_modules/@types"],
-    "useUnknownInCatchVariables": false
+    "typeRoots": ["./node_modules/@types"]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "baseUrl": "./src",
-    "typeRoots": ["./node_modules/@types"]
+    "typeRoots": ["./node_modules/@types"],
+    "useUnknownInCatchVariables": false
   }
 }


### PR DESCRIPTION
prototype/proposal patch implementing functionality discussed in issue #20 for adding optional links (external and internal) to graph nodes. Link parameters format is similar to the `details__` field: 
```
link__{uniquename}__parameter = value
```

## External Links
- `link__id__url`, `link__id__title` 

## Internal Links
- `link__id__expr`, `link__id__uid`, `link__id__name`

### Format Sample
```json
{ 
  "id": "1", 
  "title": "Service1", 
  "subTitle": "instance:#2", 
  "detail__role": "load",
  "arc__failed": 0.7, 
  "arc__passed": 0.3, 
  "mainStat": "qaz",
  "link_external_url": "http://some/service",
  "link_external_title": "custom link",
  "link_internal_expr": "rate(traces_service_graph_request_total{server=\"${__data.fields.id}\"}[$__interval])",
  "link_external_title": "request rate",
  "link_internal_uid": "prometheus"
}
```